### PR TITLE
fix: the style of 'block cursor' when scrolling

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,10 @@ export interface IpadCursorConfig {
      * Cursor padding when hover on block
      */
     blockPadding?: number | "auto";
+    /**
+     * detect text node and apply text cursor automatically
+     **/
+    enableAutoTextCursor?: boolean;
 }
 /**
  * Configurable style of the cursor

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,16 +289,16 @@ function autoApplyTextCursor(target: HTMLElement) {
   resetCursorStyle();
 }
 
-const mouseLeaveEvent = new MouseEvent('mouseleave', {
-  bubbles: true,
-  cancelable: true,
-  view: window,
-});
 
 let lastNode: Element | null = null;
 const scrollHandler = () => {
   const currentNode = document.elementFromPoint(position.x, position.y);
-  if (currentNode !== lastNode && lastNode) {
+  const mouseLeaveEvent = new MouseEvent('mouseleave', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  });
+  if (currentNode !== lastNode && lastNode && mouseLeaveEvent) {
     lastNode.dispatchEvent(mouseLeaveEvent);
   }
   lastNode = currentNode;
@@ -604,11 +604,11 @@ function registerBlockNode(_node: Element) {
   function toggleNodeTransition(enable?: boolean) {
     const duration = enable
       ? Utils.getDuration(
-          config?.blockStyle?.durationPosition ??
-            config?.blockStyle?.durationBase ??
-            config?.normalStyle?.durationBase ??
-            "0.23s"
-        )
+        config?.blockStyle?.durationPosition ??
+        config?.blockStyle?.durationBase ??
+        config?.normalStyle?.durationBase ??
+        "0.23s"
+      )
       : "";
     node.style.setProperty(
       "transition",

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,22 @@ function recordMousePosition(e: MouseEvent) {
   position.y = e.clientY;
 }
 
+const mouseLeaveEvent = new MouseEvent('mouseleave', {
+  bubbles: true,
+  cancelable: true,
+  view: window,
+});
+
+let lastNode: Element | null = null;
+const scrollHandler = () => {
+  const currentNode = document.elementFromPoint(position.x, position.y);
+  if (currentNode !== lastNode && lastNode) {
+    lastNode.dispatchEvent(mouseLeaveEvent);
+  }
+  lastNode = currentNode;
+}
+
+
 /**
  * Init cursor, hide default cursor, and listen mousemove event
  * will only run once in client even if called multiple times
@@ -274,6 +290,7 @@ function initCursor(_config?: IpadCursorConfig) {
   if (_config) updateConfig(_config);
   ready = true;
   window.addEventListener("mousemove", recordMousePosition);
+  window.addEventListener("scroll", scrollHandler);
   createCursor();
   createStyle();
   updateCursorPosition();
@@ -288,6 +305,7 @@ function disposeCursor() {
   if (!ready) return;
   ready = false;
   window.removeEventListener("mousemove", recordMousePosition);
+  window.removeEventListener("scroll", scrollHandler);
   cursorEle && cursorEle.remove();
   styleTag && styleTag.remove();
   styleTag = null;
@@ -518,6 +536,9 @@ function registerBlockNode(_node: Element) {
     );
   }
   function onBlockMove() {
+    if (!isActive) {
+      onBlockEnter();
+    }
     const rect = node.getBoundingClientRect();
     const halfHeight = rect.height / 2;
     const topOffset = (position.y - rect.top - halfHeight) / halfHeight;


### PR DESCRIPTION
Currently, scrolling when the cursor is on a block element gives unexpected results.

I've added a scroll listener that restores the cursor's style if the scrolling takes the cursor out of the range of the block element.

**Limitations**

Currently it is not possible to listen to scroll events on internal scrollable elements.