### PR TITLE
feature: add react alpha version

### DIFF
--- a/src/react/README.md
+++ b/src/react/README.md
@@ -1,0 +1,22 @@
+## IPad Cursor React Component
+
+IPad Cursor support of React component usage.
+
+## Usage
+
+it had exported two function
+
+1. `IPadCursorProvider` -> add Context on the Top level code.
+    ```ts
+    <IPadCursorProvider>
+        <App/>
+    </IPadCursorProvider>
+    ```
+2. `useIPadCursor`        -> use a Hook to config
+    ```typescript
+    const {
+        updateConfig,
+        updateCursor,
+        // ... and so on 
+    } = useIPadCursor();
+    ```

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  CursorType,
+  initCursor,
+  updateCursor,
+  disposeCursor,
+  IpadCursorConfig,
+  updateConfig,
+  customCursorStyle,
+} from "..";
+import type * as CursorOutput from "..";
+
+const useIPadCursorInit = (config?: IpadCursorConfig) => {
+  useEffect(() => {
+    initCursor(config);
+    return () => {
+      disposeCursor();
+    };
+  }, [config]);
+  return {
+    CursorType,
+    disposeCursor,
+    initCursor,
+    updateCursor,
+    updateConfig,
+    customCursorStyle,
+  }
+}
+
+const CursorContext = React.createContext<Partial<typeof CursorOutput>>({})
+export function IPadCursorProvider({ children }: { children: React.ReactNode }) {
+  const { CursorType,
+    disposeCursor,
+    initCursor,
+    updateCursor,
+    updateConfig,
+    customCursorStyle, } = useIPadCursorInit();
+  return (
+    <CursorContext.Provider value={{
+      CursorType,
+      disposeCursor,
+      initCursor,
+      updateCursor,
+      updateConfig,
+      customCursorStyle,
+    }} >
+      {children}
+    </CursorContext.Provider>
+  )
+}
+
+export function useIPadCursor() {
+  return React.useContext(CursorContext)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "experimentalDecorators": true,
     "module": "esnext",
     "target": "es2019",


### PR DESCRIPTION
@CatsJuice  I add some alpha code for react export code in `index.tsx`.

I am not confident in set at rolllup code for react, so I named it "alpha".

I add two functions to export.

1. `IPadCursorProvider` -> add Context on the Top level code.
    ```ts
    <IPadCursorProvider>
        <App/>
    </IPadCursorProvider>
    ```
2. `useIPadCursor`        -> use a Hook to config
    ```typescript
    const {
        updateConfig,
        updateCursor,
        // ... and so on 
    } = useIPadCursor();
    ```