### PR TITLE
fix: Prevents falling back to the default value when using 0 values.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -395,7 +395,7 @@ function disposeCursor() {
 function updateConfig(_config: IpadCursorConfig) {
   if ("adsorptionStrength" in _config) {
     config.adsorptionStrength = Utils.clamp(
-      _config.adsorptionStrength || 10,
+      _config.adsorptionStrength ?? 10,
       0,
       30
     );
@@ -634,7 +634,7 @@ function registerBlockNode(_node: Element) {
     timer = setTimeout(() => toggleBlockActive(true));
     cursorEle && cursorEle.classList.add("block-active");
     const updateStyleObj: IpadCursorStyle = { ...(config.blockStyle || {}) };
-    const blockPadding = config.blockPadding || 0;
+    const blockPadding = config.blockPadding ?? 0;
     let padding = blockPadding;
     let radius = updateStyleObj?.radius;
     if (padding === "auto") {
@@ -683,7 +683,7 @@ function registerBlockNode(_node: Element) {
     const halfWidth = rect.width / 2;
     const leftOffset = (position.x - rect.left - halfWidth) / halfWidth;
 
-    const strength = config.adsorptionStrength || 10;
+    const strength = config.adsorptionStrength ?? 10;
     updateCursorStyle(
       "--cursor-translateX",
       `${leftOffset * ((rect.width / 100) * strength)}px`


### PR DESCRIPTION
```js
0 || 10 // 10
0 ?? 10 // 0
```

This will cause adsorptionStrength to not be set to 0.