### PR TITLE
fix: prevents the cursor from shifting from the node during rapid enter/leave

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -627,6 +627,10 @@ function registerBlockNode(_node: Element) {
     // TODO: maybe control this in other way
     cursorEle &&
       cursorEle.classList.toggle("lighting--on", !!config.enableLighting);
+    
+    // Prevents the cursor from shifting from the node during rapid enter/leave.
+    toggleNodeTransition(false);
+    
     const rect = node.getBoundingClientRect();
     timer && clearTimeout(timer);
     toggleBlockActive(true);


### PR DESCRIPTION
Currently, when moving in and out of a block quickly, the cursor position is miscalculated due to the presence of a transform in the block, resulting in an offset.

Turning off the transition on enter does not affect the animation and solves the above problem.