### PR TITLE
fix: invalid updateConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -416,7 +416,15 @@ function updateConfig(_config: IpadCursorConfig) {
       30
     );
   }
-  return Utils.mergeDeep(config, _config);
+  const newConfig = Utils.mergeDeep(config, _config);
+  if (!isBlockActive && !isTextActive && _config.normalStyle) {
+    updateCursorStyle(Utils.style2Vars(newConfig.normalStyle!));
+  } else if (isBlockActive && _config.blockStyle) {
+    updateCursorStyle(Utils.style2Vars(newConfig.blockStyle!));
+  } else if (isTextActive && _config.textStyle) {
+    updateCursorStyle(Utils.style2Vars(newConfig.textStyle!));
+  }
+  return newConfig;
 }
 
 /**


### PR DESCRIPTION
Use `updateConfig` to change cursor style is invalid.

Example:
```js
// App.vue
const { updateConfig } = useCursor();
updateConfig({ /* some styles */ });  // cursor is not changed
```

After calling `updateConfig()`, (if cursor is not moving, )cursor element style is not changed, should set cursor style in `updateConfig()`