### PR TITLE
fix: The default cursor that appears on mobile devices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ let isMouseDown = false;
 let styleTag: HTMLStyleElement | null = null;
 let latestCursorStyle: Record<string, any> = {};
 let mousedownStyleRecover: Record<string, any> = {};
-const position = { x: 0, y: 0 };
+const position = { x: -100, y: -100};
 const isServer = typeof document === "undefined";
 const registeredNodeSet = new Set<Element>();
 const eventMap = new Map<


### PR DESCRIPTION
Now, the default position of the cursor is set to 0 0, which causes a cursor in the upper left corner to appear by default on mobile devices. Therefore, I moved the initial position to -100-100 so that the cursor is not visible when first entering the page

![屏幕截图 2024-06-04 145058](https://github.com/CatsJuice/ipad-cursor/assets/67226385/4c1d0d6c-e112-4717-83ce-bfd507e8f951)
![2333](https://github.com/CatsJuice/ipad-cursor/assets/67226385/12a98ff5-dbf7-45c0-88f5-3a4744911e1d)
